### PR TITLE
feat: enrich universe overview content

### DIFF
--- a/apps/bff/src/graph/graph.service.ts
+++ b/apps/bff/src/graph/graph.service.ts
@@ -56,13 +56,17 @@ export class GraphService {
     const query = `
       MATCH (u:Universe {id: $universeId})
       OPTIONAL MATCH (u)-[:HAS_CATEGORY]->(c:Category)
+      WHERE c IS NOT NULL
       OPTIONAL MATCH (c)-[:HAS_PAGE]->(p)
-      RETURN c.name as category, collect({
+      WITH c, collect(CASE WHEN p IS NOT NULL THEN {
         id: p.id,
         name: p.name,
         title: p.title,
-        type: labels(p)[0]
-      }) as pages
+        markdown: p.markdown,
+        type: head(labels(p))
+      } END) as collectedPages
+      RETURN c.name as category,
+             [page IN collectedPages WHERE page IS NOT NULL] as pages
     `;
     return this.runQuery(query, { universeId });
   }

--- a/apps/bff/src/universes/universes.service.ts
+++ b/apps/bff/src/universes/universes.service.ts
@@ -138,7 +138,75 @@ export class UniversesService {
   }
 
   renderUniversePage(universe: any, content: any[]): string {
-    const categories = content.filter((c) => c.category).map((c) => c.category);
+    const categories = content
+      .filter((c) => c && c.category)
+      .map((c) => ({
+        name: c.category,
+        pages: Array.isArray(c.pages) ? c.pages.filter(Boolean) : [],
+      }));
+
+    const categoryCards = categories
+      .map(
+        (category) => `
+          <div class="category-card" onclick="loadCategory('${universe.id}', '${category.name}')">
+            <h3>${this.getCategoryIcon(category.name)} ${category.name}</h3>
+            <p>${this.getCategoryDescription(category.name)}</p>
+          </div>
+        `
+      )
+      .join("");
+
+    const categorySections = categories
+      .map((category) => {
+        const pages = category.pages.filter((page) => page && page.id);
+        const items = pages
+          .map((page) => {
+            const title = page.title || page.name || "Untitled";
+            const summary = page.markdown
+              ? this.markdownService.extractSummary(page.markdown)
+              : "";
+            const description = summary || "Click to read more.";
+
+            return `
+              <article class="content-item" onclick="loadPage('${page.id}')">
+                <h3>${title}</h3>
+                <p>${description}</p>
+              </article>
+            `;
+          })
+          .join("");
+
+        const emptyState = `
+          <p class="empty-category">No ${category.name.toLowerCase()} available yet.</p>
+        `;
+
+        return `
+          <section class="category-section" data-category="${category.name}">
+            <header class="category-section-header">
+              <div>
+                <h2>${this.getCategoryIcon(category.name)} ${category.name}</h2>
+                <p>${this.getCategoryDescription(category.name)}</p>
+              </div>
+              <button class="ds-button ds-button-secondary" onclick="loadCategory('${universe.id}', '${category.name}')">
+                View all ${category.name.toLowerCase()}
+              </button>
+            </header>
+            <div class="category-section-content">
+              ${items || emptyState}
+            </div>
+            <footer class="category-section-footer">
+              <button class="ds-button ds-button-primary" onclick="createContent('${category.name.toLowerCase()}')">
+                Create ${category.name.slice(0, -1)}
+              </button>
+            </footer>
+          </section>
+        `;
+      })
+      .join("");
+
+    const noContentMessage = `
+      <p class="empty-universe">No categories found for this universe yet. Try generating new content to get started.</p>
+    `;
 
     return `
       <div class="content-area">
@@ -147,21 +215,14 @@ export class UniversesService {
           <p>${universe.description || "A universe waiting to be explored"}</p>
           <button class="ds-button ds-button-secondary back-to-home">← Back to Home</button>
         </div>
-        
+
         <div class="category-grid">
-          ${categories
-            .map(
-              (category) => `
-            <div class="category-card" onclick="loadCategory('${universe.id}', '${category}')">
-              <h3>${this.getCategoryIcon(category)} ${category}</h3>
-              <p>${this.getCategoryDescription(category)}</p>
-            </div>
-          `
-            )
-            .join("")}
+          ${categoryCards}
         </div>
-        
-        <div id="category-content"></div>
+
+        <div class="category-sections">
+          ${categorySections || noContentMessage}
+        </div>
       </div>
     `;
   }

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -143,6 +143,144 @@
         min-width: 0;
       }
 
+      /* Universe detail layout */
+      .content-area {
+        display: flex;
+        flex-direction: column;
+        gap: 32px;
+      }
+
+      .hero {
+        background-color: var(--wiki-bg);
+        border: 1px solid var(--wiki-border);
+        border-radius: 3px;
+        padding: 24px;
+      }
+
+      .hero h1 {
+        margin: 0 0 12px 0;
+        font-size: 32px;
+        font-weight: normal;
+      }
+
+      .hero p {
+        margin: 0 0 16px 0;
+        color: var(--wiki-text-secondary);
+        font-size: 16px;
+      }
+
+      .category-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 16px;
+      }
+
+      .category-card {
+        background-color: var(--wiki-bg);
+        border: 1px solid var(--wiki-border);
+        border-radius: 3px;
+        padding: 16px;
+        cursor: pointer;
+        transition: border-color 0.2s, box-shadow 0.2s;
+      }
+
+      .category-card:hover {
+        border-color: var(--wiki-link);
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+      }
+
+      .category-card h3 {
+        margin: 0 0 8px 0;
+        font-size: 18px;
+        font-weight: bold;
+      }
+
+      .category-card p {
+        margin: 0;
+        color: var(--wiki-text-secondary);
+        font-size: 14px;
+        line-height: 1.4;
+      }
+
+      .category-sections {
+        display: flex;
+        flex-direction: column;
+        gap: 32px;
+      }
+
+      .category-section {
+        background-color: var(--wiki-bg);
+        border: 1px solid var(--wiki-border);
+        border-radius: 3px;
+        padding: 20px;
+      }
+
+      .category-section-header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 16px;
+        margin-bottom: 16px;
+      }
+
+      .category-section-header h2 {
+        margin: 0 0 4px 0;
+        font-size: 22px;
+      }
+
+      .category-section-header p {
+        margin: 0;
+        color: var(--wiki-text-secondary);
+        font-size: 14px;
+      }
+
+      .category-section-content {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        gap: 16px;
+      }
+
+      .content-item {
+        background-color: var(--wiki-bg);
+        border: 1px solid var(--wiki-border);
+        border-radius: 3px;
+        padding: 16px;
+        cursor: pointer;
+        transition: border-color 0.2s, box-shadow 0.2s;
+      }
+
+      .content-item:hover {
+        border-color: var(--wiki-link);
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+      }
+
+      .content-item h3 {
+        margin: 0 0 8px 0;
+        font-size: 16px;
+        font-weight: bold;
+        color: var(--wiki-text);
+      }
+
+      .content-item p {
+        margin: 0;
+        font-size: 14px;
+        color: var(--wiki-text-secondary);
+        line-height: 1.5;
+      }
+
+      .category-section-footer {
+        display: flex;
+        justify-content: flex-end;
+        margin-top: 20px;
+      }
+
+      .empty-category,
+      .empty-universe {
+        margin: 0;
+        color: var(--wiki-text-secondary);
+        font-size: 14px;
+      }
+
       /* Article styling */
       .wiki-article {
         background-color: var(--wiki-bg);
@@ -416,6 +554,23 @@
 
         .wiki-cards {
           grid-template-columns: 1fr;
+        }
+
+        .category-grid {
+          grid-template-columns: 1fr;
+        }
+
+        .category-section-header {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
+        .category-section-content {
+          grid-template-columns: 1fr;
+        }
+
+        .category-section-footer {
+          justify-content: flex-start;
         }
       }
     </style>


### PR DESCRIPTION
## Summary
- include markdown content when querying universe pages so renderers can show summaries
- render grouped category sections on the universe view with per-page summary snippets and navigation
- refresh the public styles to support the new category sections while keeping the wiki aesthetic

## Testing
- npm run lint *(fails: ESLint configuration missing in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68cf330a46588324991c0eab7890de13