### PR TITLE
feat(web): integrate Canon design tokens with Standards UI

### DIFF
--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -4,42 +4,29 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Canon - Universe Builder</title>
-    <script
-      type="module"
-      src="https://unpkg.com/standards-ui@1.33.0/dist/standards-ui.js"></script>
-    <link
-      rel="stylesheet"
-      href="https://unpkg.com/standards-ui@1.33.0/dist/standards-ui.css" />
+    <script type="module" src="/src/main.ts"></script>
     <style>
-      :root {
-        --wiki-bg: #ffffff;
-        --wiki-border: #a2a9b1;
-        --wiki-text: #202122;
-        --wiki-text-secondary: #54595d;
-        --wiki-link: #0645ad;
-        --wiki-link-hover: #0b0080;
-        --wiki-sidebar-bg: #f6f6f6;
-        --wiki-header-bg: #ffffff;
-        --wiki-header-border: #a2a9b1;
-        --wiki-content-width: 1200px;
-        --wiki-sidebar-width: 240px;
-        --wiki-margin: 16px;
-      }
-
       body {
         margin: 0;
-        font-family:
-          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-          "Helvetica Neue", Arial, sans-serif;
-        background-color: var(--wiki-bg);
-        color: var(--wiki-text);
-        line-height: 1.6;
+        font-family: var(
+          --ds-typography-font-family,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          Roboto,
+          "Helvetica Neue",
+          Arial,
+          sans-serif
+        );
+        background-color: var(--ds-color-background, #f8f9fa);
+        color: var(--ds-color-text, #202122);
+        line-height: var(--ds-typography-line-height, 1.6);
       }
 
       /* Wikipedia-style header */
       .wiki-header {
-        background-color: var(--wiki-header-bg);
-        border-bottom: 1px solid var(--wiki-header-border);
+        background-color: var(--ds-color-surface, #ffffff);
+        border-bottom: 1px solid var(--ds-color-border-strong, #a2a9b1);
         padding: 8px 0;
         position: sticky;
         top: 0;
@@ -47,29 +34,29 @@
       }
 
       .wiki-header-content {
-        max-width: var(--wiki-content-width);
+        max-width: var(--ds-layout-page-max-width, 1200px);
         margin: 0 auto;
         display: flex;
         align-items: center;
         justify-content: space-between;
-        padding: 0 var(--wiki-margin);
+        padding: 0 var(--ds-spacing-md, 16px);
       }
 
       .wiki-logo {
         font-size: 24px;
         font-weight: bold;
-        color: var(--wiki-text);
+        color: var(--ds-color-text, #202122);
         text-decoration: none;
       }
 
       .wiki-nav {
         display: flex;
-        gap: 20px;
+        gap: var(--ds-spacing-content-gap, 20px);
         align-items: center;
       }
 
       .wiki-nav a {
-        color: var(--wiki-link);
+        color: var(--ds-color-primary, #0645ad);
         text-decoration: none;
         font-size: 14px;
       }
@@ -80,20 +67,20 @@
 
       /* Main layout */
       .wiki-container {
-        max-width: var(--wiki-content-width);
+        max-width: var(--ds-layout-page-max-width, 1200px);
         margin: 0 auto;
         display: flex;
-        gap: 20px;
-        padding: 20px var(--wiki-margin);
+        gap: var(--ds-spacing-content-gap, 20px);
+        padding: 20px var(--ds-spacing-md, 16px);
       }
 
       /* Sidebar */
       .wiki-sidebar {
-        width: var(--wiki-sidebar-width);
-        background-color: var(--wiki-sidebar-bg);
-        border: 1px solid var(--wiki-border);
-        border-radius: 3px;
-        padding: 12px;
+        width: var(--ds-layout-sidebar-width, 240px);
+        background-color: var(--ds-color-surface-muted, #f6f6f6);
+        border: 1px solid var(--ds-color-border, #a2a9b1);
+        border-radius: var(--ds-shape-radius-sm, 4px);
+        padding: var(--ds-spacing-sidebar-padding, 12px);
         height: fit-content;
         position: sticky;
         top: 80px;
@@ -104,8 +91,8 @@
         padding: 0;
         font-size: 14px;
         font-weight: bold;
-        color: var(--wiki-text);
-        border-bottom: 1px solid var(--wiki-border);
+        color: var(--ds-color-text, #202122);
+        border-bottom: 1px solid var(--ds-color-border, #a2a9b1);
         padding-bottom: 4px;
       }
 
@@ -120,7 +107,7 @@
       }
 
       .wiki-sidebar a {
-        color: var(--wiki-link);
+        color: var(--ds-color-primary, #0645ad);
         text-decoration: none;
         font-size: 13px;
         display: block;
@@ -133,7 +120,7 @@
 
       .wiki-sidebar .active {
         font-weight: bold;
-        color: var(--wiki-text);
+        color: var(--ds-color-text, #202122);
       }
 
       /* Main content area */
@@ -146,14 +133,14 @@
       .content-area {
         display: flex;
         flex-direction: column;
-        gap: 32px;
+        gap: var(--ds-spacing-xl, 32px);
       }
 
       .hero {
-        background-color: var(--wiki-bg);
-        border: 1px solid var(--wiki-border);
-        border-radius: 3px;
-        padding: 24px;
+        background-color: var(--ds-color-surface, #ffffff);
+        border: 1px solid var(--ds-color-border, #a2a9b1);
+        border-radius: var(--ds-shape-radius-sm, 4px);
+        padding: var(--ds-spacing-lg, 24px);
       }
 
       .hero h1 {
@@ -164,21 +151,21 @@
 
       .hero p {
         margin: 0 0 16px 0;
-        color: var(--wiki-text-secondary);
+        color: var(--ds-color-text-muted, #54595d);
         font-size: 16px;
       }
 
       .category-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 16px;
+        gap: var(--ds-spacing-md, 16px);
       }
 
       .category-card {
-        background-color: var(--wiki-bg);
-        border: 1px solid var(--wiki-border);
-        border-radius: 3px;
-        padding: 16px;
+        background-color: var(--ds-color-surface, #ffffff);
+        border: 1px solid var(--ds-color-border, #a2a9b1);
+        border-radius: var(--ds-shape-radius-sm, 4px);
+        padding: var(--ds-spacing-card-padding, 16px);
         cursor: pointer;
         transition:
           border-color 0.2s,
@@ -186,7 +173,7 @@
       }
 
       .category-card:hover {
-        border-color: var(--wiki-link);
+        border-color: var(--ds-color-primary, #0645ad);
         box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
       }
 
@@ -198,7 +185,7 @@
 
       .category-card p {
         margin: 0;
-        color: var(--wiki-text-secondary);
+        color: var(--ds-color-text-muted, #54595d);
         font-size: 14px;
         line-height: 1.4;
       }
@@ -206,21 +193,21 @@
       .category-sections {
         display: flex;
         flex-direction: column;
-        gap: 32px;
+        gap: var(--ds-spacing-xl, 32px);
       }
 
       .category-section {
-        background-color: var(--wiki-bg);
-        border: 1px solid var(--wiki-border);
-        border-radius: 3px;
-        padding: 20px;
+        background-color: var(--ds-color-surface, #ffffff);
+        border: 1px solid var(--ds-color-border, #a2a9b1);
+        border-radius: var(--ds-shape-radius-sm, 4px);
+        padding: var(--ds-spacing-content-gap, 20px);
       }
 
       .category-section-header {
         display: flex;
         align-items: flex-start;
         justify-content: space-between;
-        gap: 16px;
+        gap: var(--ds-spacing-md, 16px);
         margin-bottom: 16px;
       }
 
@@ -231,21 +218,21 @@
 
       .category-section-header p {
         margin: 0;
-        color: var(--wiki-text-secondary);
+        color: var(--ds-color-text-muted, #54595d);
         font-size: 14px;
       }
 
       .category-section-content {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-        gap: 16px;
+        gap: var(--ds-spacing-md, 16px);
       }
 
       .content-item {
-        background-color: var(--wiki-bg);
-        border: 1px solid var(--wiki-border);
-        border-radius: 3px;
-        padding: 16px;
+        background-color: var(--ds-color-surface, #ffffff);
+        border: 1px solid var(--ds-color-border, #a2a9b1);
+        border-radius: var(--ds-shape-radius-sm, 4px);
+        padding: var(--ds-spacing-card-padding, 16px);
         cursor: pointer;
         transition:
           border-color 0.2s,
@@ -253,7 +240,7 @@
       }
 
       .content-item:hover {
-        border-color: var(--wiki-link);
+        border-color: var(--ds-color-primary, #0645ad);
         box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
       }
 
@@ -261,13 +248,13 @@
         margin: 0 0 8px 0;
         font-size: 16px;
         font-weight: bold;
-        color: var(--wiki-text);
+        color: var(--ds-color-text, #202122);
       }
 
       .content-item p {
         margin: 0;
         font-size: 14px;
-        color: var(--wiki-text-secondary);
+        color: var(--ds-color-text-muted, #54595d);
         line-height: 1.5;
       }
 
@@ -280,16 +267,16 @@
       .empty-category,
       .empty-universe {
         margin: 0;
-        color: var(--wiki-text-secondary);
+        color: var(--ds-color-text-muted, #54595d);
         font-size: 14px;
       }
 
       /* Article styling */
       .wiki-article {
-        background-color: var(--wiki-bg);
-        border: 1px solid var(--wiki-border);
-        border-radius: 3px;
-        padding: 24px;
+        background-color: var(--ds-color-surface, #ffffff);
+        border: 1px solid var(--ds-color-border, #a2a9b1);
+        border-radius: var(--ds-shape-radius-sm, 4px);
+        padding: var(--ds-spacing-lg, 24px);
       }
 
       .wiki-article h1 {
@@ -297,8 +284,8 @@
         padding: 0;
         font-size: 28px;
         font-weight: normal;
-        color: var(--wiki-text);
-        border-bottom: 1px solid var(--wiki-border);
+        color: var(--ds-color-text, #202122);
+        border-bottom: 1px solid var(--ds-color-border, #a2a9b1);
         padding-bottom: 8px;
       }
 
@@ -307,8 +294,8 @@
         padding: 0;
         font-size: 22px;
         font-weight: bold;
-        color: var(--wiki-text);
-        border-bottom: 1px solid var(--wiki-border);
+        color: var(--ds-color-text, #202122);
+        border-bottom: 1px solid var(--ds-color-border, #a2a9b1);
         padding-bottom: 4px;
       }
 
@@ -317,7 +304,7 @@
         padding: 0;
         font-size: 18px;
         font-weight: bold;
-        color: var(--wiki-text);
+        color: var(--ds-color-text, #202122);
       }
 
       .wiki-article p {
@@ -337,7 +324,7 @@
       }
 
       .wiki-article a {
-        color: var(--wiki-link);
+        color: var(--ds-color-primary, #0645ad);
         text-decoration: none;
       }
 
@@ -348,19 +335,19 @@
       /* Homepage styling */
       .wiki-homepage {
         text-align: center;
-        padding: 60px 24px;
+        padding: var(--ds-spacing-hero-vertical, 60px) var(--ds-spacing-hero-horizontal, 24px);
       }
 
       .wiki-homepage h1 {
         font-size: 36px;
         font-weight: normal;
         margin: 0 0 16px 0;
-        color: var(--wiki-text);
+        color: var(--ds-color-text, #202122);
       }
 
       .wiki-homepage .subtitle {
         font-size: 18px;
-        color: var(--wiki-text-secondary);
+        color: var(--ds-color-text-muted, #54595d);
         margin: 0 0 40px 0;
         max-width: 600px;
         margin-left: auto;
@@ -371,15 +358,15 @@
       .wiki-cards {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-        gap: 20px;
-        margin: 40px 0;
+        gap: var(--ds-spacing-content-gap, 20px);
+        margin: var(--ds-spacing-xxl, 40px) 0;
       }
 
       .wiki-card {
-        background-color: var(--wiki-bg);
-        border: 1px solid var(--wiki-border);
-        border-radius: 3px;
-        padding: 20px;
+        background-color: var(--ds-color-surface, #ffffff);
+        border: 1px solid var(--ds-color-border, #a2a9b1);
+        border-radius: var(--ds-shape-radius-sm, 4px);
+        padding: var(--ds-spacing-content-gap, 20px);
         text-align: left;
         transition: box-shadow 0.2s;
       }
@@ -392,86 +379,56 @@
         margin: 0 0 12px 0;
         font-size: 18px;
         font-weight: bold;
-        color: var(--wiki-text);
+        color: var(--ds-color-text, #202122);
       }
 
       .wiki-card p {
         margin: 0;
-        color: var(--wiki-text-secondary);
+        color: var(--ds-color-text-muted, #54595d);
         font-size: 14px;
         line-height: 1.5;
-      }
-
-      /* Button styling */
-      .wiki-btn {
-        background-color: var(--wiki-link);
-        color: white;
-        border: none;
-        padding: 8px 16px;
-        border-radius: 3px;
-        cursor: pointer;
-        font-size: 14px;
-        text-decoration: none;
-        display: inline-block;
-        transition: background-color 0.2s;
-      }
-
-      .wiki-btn:hover {
-        background-color: var(--wiki-link-hover);
-        text-decoration: none;
-      }
-
-      .wiki-btn-secondary {
-        background-color: transparent;
-        color: var(--wiki-link);
-        border: 1px solid var(--wiki-link);
-      }
-
-      .wiki-btn-secondary:hover {
-        background-color: var(--wiki-link);
-        color: white;
       }
 
       .creation-result .creation-actions {
         margin-top: 16px;
         display: flex;
         flex-wrap: wrap;
-        gap: 12px;
+        gap: var(--ds-spacing-md-plus, 12px);
       }
 
       /* Loading and error states */
       .wiki-loading {
         text-align: center;
         padding: 40px;
-        color: var(--wiki-text-secondary);
+        color: var(--ds-color-text-muted, #54595d);
       }
 
       .wiki-error {
         background-color: #ffe6e6;
         border: 1px solid #ff6b6b;
-        border-radius: 3px;
-        padding: 16px;
+        border-radius: var(--ds-shape-radius-sm, 4px);
+        padding: var(--ds-spacing-card-padding, 16px);
         margin: 16px 0;
         color: #d63031;
       }
 
       /* Content list styling */
       .wiki-content-list {
-        margin: 24px 0;
+        margin: var(--ds-spacing-lg, 24px) 0;
       }
 
       .wiki-content-item {
-        background-color: var(--wiki-bg);
-        border: 1px solid var(--wiki-border);
-        border-radius: 3px;
-        padding: 16px;
+        background-color: var(--ds-color-surface, #ffffff);
+        border: 1px solid var(--ds-color-border, #a2a9b1);
+        border-radius: var(--ds-shape-radius-sm, 4px);
+        padding: var(--ds-spacing-card-padding, 16px);
         margin-bottom: 12px;
         cursor: pointer;
         transition: all 0.2s;
       }
 
       .wiki-content-item:hover {
-        border-color: var(--wiki-link);
+        border-color: var(--ds-color-primary, #0645ad);
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
       }
 
@@ -479,21 +436,21 @@
         margin: 0 0 8px 0;
         font-size: 16px;
         font-weight: bold;
-        color: var(--wiki-text);
+        color: var(--ds-color-text, #202122);
       }
 
       .wiki-content-item p {
         margin: 0;
         font-size: 14px;
-        color: var(--wiki-text-secondary);
+        color: var(--ds-color-text-muted, #54595d);
       }
 
       /* Universe item styling */
       .universe-item {
-        background-color: var(--wiki-bg);
-        border: 1px solid var(--wiki-border);
-        border-radius: 3px;
-        padding: 16px;
+        background-color: var(--ds-color-surface, #ffffff);
+        border: 1px solid var(--ds-color-border, #a2a9b1);
+        border-radius: var(--ds-shape-radius-sm, 4px);
+        padding: var(--ds-spacing-card-padding, 16px);
         margin-bottom: 12px;
         cursor: pointer;
         transition: all 0.2s;
@@ -502,13 +459,13 @@
       }
 
       .universe-item:hover {
-        border-color: var(--wiki-link);
+        border-color: var(--ds-color-primary, #0645ad);
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
         background-color: #f8f9fa;
       }
 
       .universe-item strong {
-        color: var(--wiki-text);
+        color: var(--ds-color-text, #202122);
         font-size: 16px;
         font-weight: bold;
         display: block;
@@ -516,14 +473,14 @@
       }
 
       .universe-item small {
-        color: var(--wiki-text-secondary);
+        color: var(--ds-color-text-muted, #54595d);
         font-size: 14px;
         line-height: 1.4;
       }
 
       .universe-item.active {
-        border-color: var(--wiki-link);
-        background-color: #e3f2fd;
+        border-color: var(--ds-color-primary, #0645ad);
+        background-color: var(--ds-color-highlight, #e3f2fd);
       }
 
       /* Modal styling */
@@ -533,7 +490,7 @@
         left: 0;
         width: 100%;
         height: 100%;
-        background-color: rgba(0, 0, 0, 0.5);
+        background-color: var(--ds-color-overlay, rgba(0, 0, 0, 0.5));
         display: none;
         justify-content: center;
         align-items: center;
@@ -545,10 +502,10 @@
       }
 
       .modal {
-        background-color: var(--wiki-bg);
-        border: 1px solid var(--wiki-border);
-        border-radius: 3px;
-        padding: 24px;
+        background-color: var(--ds-color-surface, #ffffff);
+        border: 1px solid var(--ds-color-border, #a2a9b1);
+        border-radius: var(--ds-shape-radius-sm, 4px);
+        padding: var(--ds-spacing-lg, 24px);
         max-width: 500px;
         width: 90%;
         max-height: 90vh;
@@ -560,13 +517,13 @@
         margin: 0 0 16px 0;
         font-size: 24px;
         font-weight: bold;
-        color: var(--wiki-text);
+        color: var(--ds-color-text, #202122);
       }
 
       .modal-form {
         display: flex;
         flex-direction: column;
-        gap: 16px;
+        gap: var(--ds-spacing-md, 16px);
       }
 
       .form-group {
@@ -578,45 +535,45 @@
       .form-group label {
         font-size: 14px;
         font-weight: bold;
-        color: var(--wiki-text);
+        color: var(--ds-color-text, #202122);
       }
 
       .form-group input {
         padding: 8px 12px;
-        border: 1px solid var(--wiki-border);
-        border-radius: 3px;
+        border: 1px solid var(--ds-color-border, #a2a9b1);
+        border-radius: var(--ds-shape-radius-sm, 4px);
         font-size: 14px;
-        background-color: var(--wiki-bg);
-        color: var(--wiki-text);
+        background-color: var(--ds-color-surface, #ffffff);
+        color: var(--ds-color-text, #202122);
       }
 
       .form-group input:focus {
         outline: none;
-        border-color: var(--wiki-link);
+        border-color: var(--ds-color-primary, #0645ad);
         box-shadow: 0 0 0 2px rgba(6, 69, 173, 0.2);
       }
 
       .modal-actions {
         display: flex;
-        gap: 12px;
+        gap: var(--ds-spacing-md-plus, 12px);
         justify-content: flex-end;
         margin-top: 8px;
       }
 
-      .modal-actions .wiki-btn {
+      .modal-actions ds-button {
         min-width: 80px;
       }
 
       /* Queue page styling */
       .queue-stats {
-        margin: 24px 0;
+        margin: var(--ds-spacing-lg, 24px) 0;
       }
 
       .queue-summary {
-        background-color: var(--wiki-bg);
-        border: 1px solid var(--wiki-border);
-        border-radius: 3px;
-        padding: 20px;
+        background-color: var(--ds-color-surface, #ffffff);
+        border: 1px solid var(--ds-color-border, #a2a9b1);
+        border-radius: var(--ds-shape-radius-sm, 4px);
+        padding: var(--ds-spacing-content-gap, 20px);
         margin-bottom: 24px;
       }
 
@@ -624,72 +581,72 @@
         margin: 0 0 16px 0;
         font-size: 22px;
         font-weight: bold;
-        color: var(--wiki-text);
+        color: var(--ds-color-text, #202122);
       }
 
       .stats-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-        gap: 16px;
+        gap: var(--ds-spacing-md, 16px);
       }
 
       .stat-card {
-        background-color: var(--wiki-sidebar-bg);
-        border: 1px solid var(--wiki-border);
-        border-radius: 3px;
-        padding: 16px;
+        background-color: var(--ds-color-surface-muted, #f6f6f6);
+        border: 1px solid var(--ds-color-border, #a2a9b1);
+        border-radius: var(--ds-shape-radius-sm, 4px);
+        padding: var(--ds-spacing-card-padding, 16px);
         text-align: center;
         transition: all 0.2s;
       }
 
       .stat-card:hover {
-        border-color: var(--wiki-link);
+        border-color: var(--ds-color-primary, #0645ad);
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
       }
 
       .stat-card.waiting {
-        border-left: 4px solid #ffc107;
+        border-left: 4px solid var(--ds-color-warning, #ffc107);
       }
 
       .stat-card.active {
-        border-left: 4px solid #007bff;
+        border-left: 4px solid var(--ds-color-primary, #0645ad);
       }
 
       .stat-card.completed {
-        border-left: 4px solid #28a745;
+        border-left: 4px solid var(--ds-color-success, #28a745);
       }
 
       .stat-card.failed {
-        border-left: 4px solid #dc3545;
+        border-left: 4px solid var(--ds-color-danger, #dc3545);
       }
 
       .stat-number {
         font-size: 24px;
         font-weight: bold;
-        color: var(--wiki-text);
+        color: var(--ds-color-text, #202122);
         margin-bottom: 4px;
       }
 
       .stat-label {
         font-size: 14px;
-        color: var(--wiki-text-secondary);
+        color: var(--ds-color-text-muted, #54595d);
         text-transform: uppercase;
         letter-spacing: 0.5px;
       }
 
       .queue-jobs {
-        margin: 24px 0;
+        margin: var(--ds-spacing-lg, 24px) 0;
       }
 
       .queue-controls {
         display: flex;
-        gap: 12px;
+        gap: var(--ds-spacing-md-plus, 12px);
         margin-top: 24px;
         padding-top: 16px;
-        border-top: 1px solid var(--wiki-border);
+        border-top: 1px solid var(--ds-color-border, #a2a9b1);
       }
 
-      .queue-controls .wiki-btn {
+      .queue-controls ds-button {
         min-width: 120px;
       }
 
@@ -713,16 +670,16 @@
       @media (max-width: 768px) {
         .wiki-header-content {
           flex-direction: column;
-          gap: 12px;
+          gap: var(--ds-spacing-md-plus, 12px);
           text-align: center;
         }
 
         .wiki-container {
-          padding: 12px;
+          padding: var(--ds-spacing-sidebar-padding, 12px);
         }
 
         .wiki-article {
-          padding: 16px;
+          padding: var(--ds-spacing-card-padding, 16px);
         }
 
         .wiki-homepage {
@@ -759,7 +716,7 @@
           align-items: stretch;
         }
 
-        .queue-controls .wiki-btn {
+        .queue-controls ds-button {
           width: 100%;
         }
 
@@ -832,12 +789,12 @@
               species, cultures, and technologies.
             </p>
 
-            <a
-              href="#"
-              class="wiki-btn"
-              onclick="createNewUniverse(); return false;">
+            <ds-button
+              type="button"
+              variant="primary"
+              onclick="createNewUniverse();">
               Create Your First Universe
-            </a>
+            </ds-button>
 
             <div class="wiki-cards">
               <div class="wiki-card">
@@ -905,53 +862,16 @@
               required />
           </div>
           <div class="modal-actions">
-            <button
-              type="button"
-              class="wiki-btn wiki-btn-secondary"
-              onclick="hideUniverseModal()">
+            <ds-button type="button" variant="secondary" onclick="hideUniverseModal()">
               Cancel
-            </button>
-            <button type="submit" class="wiki-btn">Create Universe</button>
+            </ds-button>
+            <ds-button type="submit" variant="primary">Create Universe</ds-button>
           </div>
         </form>
       </div>
     </div>
 
     <script>
-      // Initialize standards-ui with ES6 modules
-      document.addEventListener("DOMContentLoaded", async function () {
-        console.log("DOM loaded, checking for StandardsUI...");
-
-        try {
-          // Try to import StandardsUI as ES6 module
-          const { StandardsUI } = await import(
-            "https://unpkg.com/standards-ui@1.33.0/dist/standards-ui.js"
-          );
-          console.log("StandardsUI imported successfully:", StandardsUI);
-
-          if (StandardsUI && typeof StandardsUI.init === "function") {
-            console.log("Initializing StandardsUI...");
-            const tokens = StandardsUI.DEFAULT_TOKENS;
-            console.log("Using tokens:", tokens);
-            StandardsUI.init(tokens);
-            console.log("StandardsUI initialized successfully!");
-          } else {
-            console.log("StandardsUI.init not available");
-          }
-        } catch (error) {
-          console.error("Error importing StandardsUI:", error);
-
-          // Fallback: check window object
-          console.log("Checking window.StandardsUI:", window.StandardsUI);
-          if (typeof window.StandardsUI !== "undefined") {
-            console.log("Using window.StandardsUI fallback...");
-            const tokens = window.StandardsUI.DEFAULT_TOKENS;
-            window.StandardsUI.init(tokens);
-            console.log("StandardsUI initialized via window object!");
-          }
-        }
-      });
-
       // URL Routing Functions
       function updateURL(path, state, options = {}) {
         const { replace = false } = options;
@@ -1753,10 +1673,14 @@
             </div>
             
             <div class="queue-controls">
-              <button class="wiki-btn" onclick="refreshQueueData()">Refresh</button>
-              <button class="wiki-btn wiki-btn-secondary" onclick="toggleQueuePolling()" id="polling-toggle">
+              <ds-button type="button" variant="primary" onclick="refreshQueueData()">Refresh</ds-button>
+              <ds-button
+                type="button"
+                variant="secondary"
+                onclick="toggleQueuePolling()"
+                id="polling-toggle">
                 Start Auto-Refresh
-              </button>
+              </ds-button>
             </div>
           </div>
         `;
@@ -1946,9 +1870,9 @@
                 species, cultures, and technologies.
               </p>
 
-              <a href="#" class="wiki-btn" onclick="createNewUniverse()">
+              <ds-button type="button" variant="primary" onclick="createNewUniverse()">
                 Create Your First Universe
-              </a>
+              </ds-button>
 
               <div class="wiki-cards">
                 <div class="wiki-card">

--- a/apps/web/src/design-system/README.md
+++ b/apps/web/src/design-system/README.md
@@ -1,0 +1,66 @@
+# Canon Design Tokens
+
+This folder defines the design language that Standards UI consumes when it renders the Canon web experience. The token map in [`tokens.ts`](./tokens.ts) is passed to `StandardsUI.init` so the design system injects consistent CSS custom properties before any components render. The sections below summarize the semantics behind the tokens so component authors can reuse them confidently.
+
+## Color palette
+
+| Token | Purpose |
+| --- | --- |
+| `color.primary` | Canon's accent blue, used for primary buttons, links, and focused interactive elements. |
+| `color.primaryHover` / `color.primaryActive` | Darker blue shades that the design system applies on hover and pressed states for primary buttons. |
+| `color.secondary` | Muted charcoal used for secondary text or subdued accents. |
+| `color.tertiary` | Neutral border tone for dividers and outlines. |
+| `color.text` | Main body text color. |
+| `color.textMuted` | Subheadings, helper text, and metadata. |
+| `color.background` | App background color behind page surfaces. |
+| `color.surface` | Default card and article surface color. |
+| `color.surfaceMuted` | Subtle backgrounds such as the sidebar and statistic tiles. |
+| `color.surfaceRaised` / `color.highlight` | Elevated backgrounds used to indicate active selections. |
+| `color.border` / `color.borderStrong` | Standard and emphasis border colors for cards, panels, and separators. |
+| `color.overlay` | Backdrop color for overlays and modals. |
+| `color.success`, `color.warning`, `color.danger`, `color.info` | Status indicators for queue metrics, toast messages, and destructive actions. |
+
+## Typography tokens
+
+- `typography.fontFamily`: Canon's sans-serif system stack used across body copy.
+- `typography.headingFontFamily`: Serif accent face for hero and article headings.
+- `typography.fontSize` & `typography.lineHeight`: Baseline rhythm for paragraphs.
+- `typography.headingWeight` / `headingLineHeight`: Provide consistent hierarchy for headings rendered by Standards UI components.
+
+## Spacing scale
+
+Spacing tokens create a shared rhythm for layout primitives:
+
+- `spacing.xs` / `spacing.sm` / `spacing.md`: Compact spacing for inline elements, list items, and form controls.
+- `spacing.mdPlus`: 12px step used for gutters inside cards and modal controls.
+- `spacing.lg`, `spacing.xl`, `spacing.xxl`, `spacing.xxxl`: Larger steps for card padding, section breaks, and hero blocks.
+- `spacing.pagePadding`: Horizontal padding applied at the page level.
+- `spacing.contentGap`: Default gap between major layout regions.
+- `spacing.cardPadding`: Internal padding for cards, tiles, and article sections.
+- `spacing.sidebarPadding`: Narrow padding used inside the navigation sidebar.
+- `spacing.heroVertical` / `spacing.heroHorizontal`: Padding scale for homepage hero content.
+- `spacing.modalPadding`: Interior spacing for modal content areas.
+
+## Layout primitives
+
+- `layout.pageMaxWidth`: Keeps long-form content readable on wide displays.
+- `layout.sidebarWidth`: Fixed width for navigation stacks.
+- `layout.contentGap`: Shared gap between the sidebar and main content.
+- `layout.cardGridMin`: Minimum tile width for responsive grids.
+
+## Shape tokens
+
+- `shape.radiusSm`, `shape.radiusMd`, `shape.radiusLg`: Corner radii used by cards, modals, and buttons to maintain consistent curvature.
+- `shape.borderWidth`: Default border thickness across surfaces.
+
+## Component-specific overrides
+
+The `components.button` block maps the canonical color palette to Standards UI button variants:
+
+- **Primary** – Solid blue call-to-action used for the main path in flows.
+- **Secondary** – Transparent outline button for secondary actions and navigation controls.
+- **Danger** – Red destructive button for irreversible actions (e.g., queue cancellation).
+
+Each variant includes hover, focus, active, and disabled state overrides so interactive feedback stays on brand.
+
+When adding new components, prefer reusing these tokens instead of hard-coding colors or spacing. If a new semantic slot is required (for example, a "tertiary" surface for charts), extend `tokens.ts` so the semantics remain centralized.

--- a/apps/web/src/design-system/tokens.ts
+++ b/apps/web/src/design-system/tokens.ts
@@ -1,0 +1,148 @@
+import type { DesignTokens } from "standards-ui";
+
+export const tokens: DesignTokens = {
+  color: {
+    primary: "#0645ad",
+    primaryHover: "#0b0080",
+    primaryActive: "#052c6e",
+    secondary: "#54595d",
+    tertiary: "#a2a9b1",
+    text: "#202122",
+    textMuted: "#54595d",
+    background: "#f8f9fa",
+    surface: "#ffffff",
+    surfaceMuted: "#f6f6f6",
+    surfaceRaised: "#f0f4ff",
+    border: "#a2a9b1",
+    borderStrong: "#72777d",
+    highlight: "#e3f2fd",
+    overlay: "rgba(32, 33, 36, 0.55)",
+    success: "#28a745",
+    warning: "#ffc107",
+    danger: "#dc3545",
+    info: "#17a2b8",
+  },
+  spacing: {
+    xs: "4px",
+    sm: "8px",
+    md: "16px",
+    mdPlus: "12px",
+    lg: "24px",
+    xl: "32px",
+    xxl: "40px",
+    xxxl: "60px",
+    pagePadding: "20px",
+    contentGap: "20px",
+    cardPadding: "16px",
+    sidebarPadding: "12px",
+    heroVertical: "60px",
+    heroHorizontal: "24px",
+    modalPadding: "24px",
+  },
+  typography: {
+    fontFamily:
+      '"Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+    fontSize: "16px",
+    lineHeight: "1.6",
+    headingFontFamily:
+      '"Source Serif Pro", "Merriweather", "Georgia", serif',
+    headingWeight: "600",
+    headingLineHeight: "1.3",
+  },
+  layout: {
+    pageMaxWidth: "1200px",
+    sidebarWidth: "240px",
+    contentGap: "20px",
+    cardGridMin: "220px",
+  },
+  shape: {
+    radiusSm: "4px",
+    radiusMd: "6px",
+    radiusLg: "12px",
+    borderWidth: "1px",
+  },
+  components: {
+    button: {
+      borderRadius: "4px",
+      padding: "8px 16px",
+      fontWeight: "500",
+      transition: "all 0.2s ease-in-out",
+      variants: {
+        primary: {
+          backgroundColor: "#0645ad",
+          borderColor: "#0645ad",
+          textColor: "#ffffff",
+          states: {
+            hover: {
+              backgroundColor: "#0b0080",
+              borderColor: "#0b0080",
+            },
+            focus: {
+              boxShadow: "0 0 0 0.2rem rgba(6, 69, 173, 0.3)",
+            },
+            active: {
+              backgroundColor: "#052c6e",
+              borderColor: "#052c6e",
+            },
+            disabled: {
+              backgroundColor: "#a2a9b1",
+              borderColor: "#a2a9b1",
+              textColor: "#f8f9fa",
+              cursor: "not-allowed",
+              opacity: "0.6",
+            },
+          },
+        },
+        secondary: {
+          backgroundColor: "transparent",
+          borderColor: "#0645ad",
+          textColor: "#0645ad",
+          states: {
+            hover: {
+              backgroundColor: "#0645ad",
+              borderColor: "#0645ad",
+              textColor: "#ffffff",
+            },
+            focus: {
+              boxShadow: "0 0 0 0.2rem rgba(6, 69, 173, 0.2)",
+            },
+            disabled: {
+              backgroundColor: "transparent",
+              borderColor: "#a2a9b1",
+              textColor: "#a2a9b1",
+              cursor: "not-allowed",
+              opacity: "0.6",
+            },
+          },
+        },
+        danger: {
+          backgroundColor: "#dc3545",
+          borderColor: "#dc3545",
+          textColor: "#ffffff",
+          states: {
+            hover: {
+              backgroundColor: "#c82333",
+              borderColor: "#c82333",
+            },
+            focus: {
+              boxShadow: "0 0 0 0.2rem rgba(220, 53, 69, 0.3)",
+            },
+            active: {
+              backgroundColor: "#b21f2d",
+              borderColor: "#b21f2d",
+            },
+            disabled: {
+              backgroundColor: "#f1a6ae",
+              borderColor: "#f1a6ae",
+              textColor: "#ffffff",
+              cursor: "not-allowed",
+              opacity: "0.6",
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+export default tokens;

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -1,0 +1,78 @@
+import "standards-ui/dist/styles.css";
+import * as StandardsUI from "standards-ui";
+import type { DesignTokens } from "standards-ui";
+
+import tokens from "./design-system/tokens";
+
+function mergeWithDefaults(
+  defaults: DesignTokens | undefined,
+  overrides: DesignTokens
+): DesignTokens {
+  const base = defaults ?? ({} as DesignTokens);
+
+  const merged: DesignTokens = {
+    ...base,
+    ...overrides,
+    color: {
+      ...base?.color,
+      ...overrides.color,
+    },
+    spacing: {
+      ...base?.spacing,
+      ...overrides.spacing,
+    },
+    typography: {
+      ...base?.typography,
+      ...overrides.typography,
+    },
+    layout: {
+      ...base?.layout,
+      ...overrides.layout,
+    },
+    components: {
+      ...base?.components,
+      ...overrides.components,
+      button: {
+        ...base?.components?.button,
+        ...overrides.components?.button,
+        variants: {
+          ...base?.components?.button?.variants,
+          ...overrides.components?.button?.variants,
+          primary: {
+            ...base?.components?.button?.variants?.primary,
+            ...overrides.components?.button?.variants?.primary,
+            states: {
+              ...base?.components?.button?.variants?.primary?.states,
+              ...overrides.components?.button?.variants?.primary?.states,
+            },
+          },
+          secondary: {
+            ...base?.components?.button?.variants?.secondary,
+            ...overrides.components?.button?.variants?.secondary,
+            states: {
+              ...base?.components?.button?.variants?.secondary?.states,
+              ...overrides.components?.button?.variants?.secondary?.states,
+            },
+          },
+          danger: {
+            ...base?.components?.button?.variants?.danger,
+            ...overrides.components?.button?.variants?.danger,
+            states: {
+              ...base?.components?.button?.variants?.danger?.states,
+              ...overrides.components?.button?.variants?.danger?.states,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  return merged;
+}
+
+const mergedTokens = mergeWithDefaults(StandardsUI.DEFAULT_TOKENS, tokens);
+const initResult = StandardsUI.init(mergedTokens);
+
+if (!initResult.success) {
+  console.error("Failed to initialize Standards UI", initResult.errors);
+}

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -1,4 +1,8 @@
 import { defineConfig } from "vite";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = fileURLToPath(new URL(".", import.meta.url));
 
 export default defineConfig({
   root: "public",
@@ -6,8 +10,16 @@ export default defineConfig({
     outDir: "../dist",
     emptyOutDir: true,
   },
+  resolve: {
+    alias: {
+      "@": path.resolve(rootDir, "src"),
+    },
+  },
   server: {
     port: 8080,
     host: true,
+    fs: {
+      allow: [rootDir, path.resolve(rootDir, "src")],
+    },
   },
 });


### PR DESCRIPTION
## Summary
- add Canon design tokens and documentation for Standards UI consumers
- initialize Standards UI with the brand tokens before component usage
- refactor the public HTML to consume the new tokens and built-in button variants

## Testing
- npm run lint *(fails: repository does not include an ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d1bda9231483249f0373812c0669b2