### PR TITLE
Add universe graph endpoint and NVL visualization tab

### DIFF
--- a/apps/bff/src/universes/dto/universe.dto.ts
+++ b/apps/bff/src/universes/dto/universe.dto.ts
@@ -23,6 +23,64 @@ export class UniverseDto {
   categories?: string[];
 }
 
+export class GraphNodeDto {
+  @ApiProperty({ description: "Unique node identifier", example: "w_terra_nova" })
+  id: string;
+
+  @ApiProperty({
+    description: "Node labels assigned within Neo4j",
+    example: ["World", "Page"],
+  })
+  labels: string[];
+
+  @ApiProperty({
+    description: "Node properties",
+    type: Object,
+    example: {
+      name: "Terra Nova",
+      type: "Terrestrial",
+      markdown: "# Terra Nova",
+    },
+  })
+  properties: Record<string, unknown>;
+
+  @ApiProperty({
+    description: "Preferred caption to display in visualizations",
+    example: "Terra Nova",
+    required: false,
+  })
+  caption?: string;
+}
+
+export class GraphRelationshipDto {
+  @ApiProperty({ description: "Unique relationship identifier", example: "123" })
+  id: string;
+
+  @ApiProperty({ description: "Relationship type", example: "HAS_PAGE" })
+  type: string;
+
+  @ApiProperty({ description: "Starting node identifier", example: "Worlds" })
+  start: string;
+
+  @ApiProperty({ description: "Target node identifier", example: "w_terra_nova" })
+  end: string;
+
+  @ApiProperty({
+    description: "Relationship properties",
+    type: Object,
+    example: {},
+  })
+  properties: Record<string, unknown>;
+}
+
+export class UniverseGraphDto {
+  @ApiProperty({ type: [GraphNodeDto] })
+  nodes: GraphNodeDto[];
+
+  @ApiProperty({ type: [GraphRelationshipDto] })
+  relationships: GraphRelationshipDto[];
+}
+
 export class WorldDto {
   @ApiProperty({
     description: "Unique world identifier",

--- a/apps/bff/src/universes/universes.controller.ts
+++ b/apps/bff/src/universes/universes.controller.ts
@@ -16,6 +16,7 @@ import {
   TimelineEventDto,
   SpatialWorldDto,
   ApiResponseDto,
+  UniverseGraphDto,
 } from "./dto/universe.dto";
 
 @ApiTags("universes")
@@ -422,6 +423,40 @@ export class UniversesController {
       res.status(500).json({
         success: false,
         error: error.message,
+      });
+    }
+  }
+
+  @Get("api/universes/:id/graph")
+  @ApiOperation({
+    summary: "Get universe graph",
+    description:
+      "Retrieve the nodes and relationships that compose the universe's knowledge graph",
+  })
+  @ApiParam({
+    name: "id",
+    description: "Universe identifier",
+    example: "u_demo",
+  })
+  @ApiResponse({
+    status: 200,
+    description: "Universe graph retrieved successfully",
+    type: ApiResponseDto<UniverseGraphDto>,
+  })
+  @ApiResponse({ status: 500, description: "Internal server error" })
+  async getUniverseGraphApi(@Param("id") id: string, @Res() res: Response) {
+    try {
+      const graph = await this.universesService.getUniverseGraph(id);
+      res.setHeader("Content-Type", "application/json");
+      res.json({
+        success: true,
+        data: graph,
+      });
+    } catch (error) {
+      console.error("Error getting universe graph:", error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
       });
     }
   }

--- a/apps/bff/src/universes/universes.service.ts
+++ b/apps/bff/src/universes/universes.service.ts
@@ -38,6 +38,10 @@ export class UniversesService {
     return this.graphService.getPageContent(pageId);
   }
 
+  async getUniverseGraph(universeId: string) {
+    return this.graphService.getUniverseGraph(universeId);
+  }
+
   async createNewUniverse(name?: string) {
     // Create universe directly in the database
     const universeId = `u_${Date.now().toString(36)}${Math.random().toString(36).substr(2, 4)}`;

--- a/apps/web/public/main.ts
+++ b/apps/web/public/main.ts
@@ -14,6 +14,7 @@ import "../src/components/canon-home";
 import "../src/components/canon-universe-sidebar";
 import "../src/components/canon-universe-list";
 import "../src/components/canon-universe-detail";
+import "../src/components/canon-universe-graph";
 import "../src/components/canon-category-panel";
 import "../src/components/canon-page-viewer";
 import "../src/components/canon-queue-dashboard";

--- a/apps/web/src/components/canon-universe-detail.ts
+++ b/apps/web/src/components/canon-universe-detail.ts
@@ -2,9 +2,13 @@ import { appStore } from '../state/app-store';
 import type { AppState } from '../state/app-store';
 import type { UniverseCategory, UniverseDetail } from '../services/api';
 
+import './canon-universe-graph';
+
 class CanonUniverseDetail extends HTMLElement {
   private unsubscribe?: () => void;
   private state: AppState | null = null;
+  private activeTab: 'overview' | 'graph' = 'overview';
+  private currentUniverseId?: string;
 
   connectedCallback(): void {
     if (!this.shadowRoot) {
@@ -32,14 +36,27 @@ class CanonUniverseDetail extends HTMLElement {
     const route = this.state.route;
     if (route.view !== 'universe') {
       this.shadowRoot.innerHTML = '';
+      this.currentUniverseId = undefined;
+      this.activeTab = 'overview';
       return;
     }
 
     const universeId = route.universeId;
+    if (this.currentUniverseId !== universeId) {
+      this.currentUniverseId = universeId;
+      this.activeTab = 'overview';
+    }
+
     const detail = this.state.universeDetails[universeId];
     const categories = this.state.universeCategories[universeId] ?? [];
-    const isLoading = this.state.loading.universe || this.state.loading.category;
-    const error = this.state.errors.universe ?? this.state.errors.category;
+    const isOverviewLoading =
+      this.state.loading.universe || this.state.loading.category;
+    const overviewError = this.state.errors.universe ?? this.state.errors.category;
+    const isGraphActive = this.activeTab === 'graph';
+
+    if (isGraphActive) {
+      appStore.ensureUniverseGraph(universeId);
+    }
 
     this.shadowRoot.innerHTML = `
       <style>
@@ -84,6 +101,33 @@ class CanonUniverseDetail extends HTMLElement {
           border-radius: 999px;
         }
 
+        .tabs {
+          display: flex;
+          gap: 12px;
+          margin-bottom: 24px;
+        }
+
+        .tabs button {
+          background: rgba(51, 102, 204, 0.08);
+          border: none;
+          border-radius: 999px;
+          padding: 10px 18px;
+          font: inherit;
+          color: rgba(32, 33, 34, 0.72);
+          cursor: pointer;
+          transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .tabs button[data-active="true"] {
+          background: #3366cc;
+          color: #ffffff;
+          box-shadow: 0 12px 24px rgba(51, 102, 204, 0.28);
+        }
+
+        .tab-content {
+          min-height: 320px;
+        }
+
         .categories {
           display: grid;
           grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
@@ -122,10 +166,13 @@ class CanonUniverseDetail extends HTMLElement {
           padding: 28px;
           border-radius: 14px;
           text-align: center;
-          margin-top: 20px;
+          background: #ffffff;
+          border: 1px solid rgba(162, 169, 177, 0.24);
+          box-shadow: 0 12px 30px rgba(18, 23, 40, 0.08);
         }
 
         .loading {
+          color: #1f409c;
           background: rgba(51, 102, 204, 0.08);
         }
 
@@ -141,19 +188,97 @@ class CanonUniverseDetail extends HTMLElement {
       </style>
       <section>
         ${this.renderHero(detail)}
-        ${isLoading
-          ? '<div class="loading">Loading universe details…</div>'
-          : error
-          ? `<div class="error">${error}</div>`
-          : categories.length === 0
-          ? '<div class="empty">This universe has no categories yet.</div>'
-          : `<div class="categories">${categories
-              .map((category) => this.renderCategoryCard(universeId, category))
-              .join('')}</div>`}
+        <div class="tabs" role="tablist" aria-label="Universe views">
+          <button
+            type="button"
+            role="tab"
+            data-tab="overview"
+            data-active="${this.activeTab === 'overview'}"
+            aria-selected="${this.activeTab === 'overview'}"
+          >
+            Overview
+          </button>
+          <button
+            type="button"
+            role="tab"
+            data-tab="graph"
+            data-active="${isGraphActive}"
+            aria-selected="${isGraphActive}"
+          >
+            Graph
+          </button>
+        </div>
+        <div class="tab-content">
+          ${isGraphActive
+            ? `<canon-universe-graph universe-id="${universeId}"></canon-universe-graph>`
+            : this.renderOverviewContent(
+                universeId,
+                categories,
+                isOverviewLoading,
+                overviewError
+              )}
+        </div>
       </section>
     `;
 
-    const viewButtons = this.shadowRoot.querySelectorAll<HTMLButtonElement>('ds-button[data-category]');
+    this.bindTabEvents(universeId);
+    if (!isGraphActive) {
+      this.bindOverviewCategoryEvents(universeId);
+    }
+  }
+
+  private renderOverviewContent(
+    universeId: string,
+    categories: UniverseCategory[],
+    isLoading: boolean,
+    error?: string
+  ): string {
+    if (isLoading) {
+      return '<div class="loading">Loading universe details…</div>';
+    }
+
+    if (error) {
+      return `<div class="error">${error}</div>`;
+    }
+
+    if (categories.length === 0) {
+      return '<div class="empty">This universe has no categories yet.</div>';
+    }
+
+    return `<div class="categories">${categories
+      .map((category) => this.renderCategoryCard(universeId, category))
+      .join('')}</div>`;
+  }
+
+  private bindTabEvents(universeId: string): void {
+    if (!this.shadowRoot) {
+      return;
+    }
+
+    const buttons = this.shadowRoot.querySelectorAll<HTMLButtonElement>(
+      'button[data-tab]'
+    );
+
+    buttons.forEach((button) => {
+      const tab = button.getAttribute('data-tab');
+      if (tab !== 'overview' && tab !== 'graph') {
+        return;
+      }
+
+      button.dataset.active = this.activeTab === tab ? 'true' : 'false';
+      button.onclick = () => this.switchTab(tab, universeId);
+    });
+  }
+
+  private bindOverviewCategoryEvents(universeId: string): void {
+    if (!this.shadowRoot) {
+      return;
+    }
+
+    const viewButtons = this.shadowRoot.querySelectorAll<HTMLButtonElement>(
+      'ds-button[data-category]'
+    );
+
     viewButtons.forEach((button) => {
       const category = button.getAttribute('data-category');
       if (!category) {
@@ -161,9 +286,28 @@ class CanonUniverseDetail extends HTMLElement {
       }
 
       button.onclick = () => {
-        appStore.navigate({ view: 'category', universeId, categoryName: category });
+        appStore.navigate({
+          view: 'category',
+          universeId,
+          categoryName: category,
+        });
       };
     });
+  }
+
+  private switchTab(tab: 'overview' | 'graph', universeId: string): void {
+    if (this.activeTab === tab) {
+      if (tab === 'graph') {
+        appStore.ensureUniverseGraph(universeId);
+      }
+      return;
+    }
+
+    this.activeTab = tab;
+    if (tab === 'graph') {
+      appStore.ensureUniverseGraph(universeId);
+    }
+    this.render();
   }
 
   private renderHero(detail: UniverseDetail | undefined): string {

--- a/apps/web/src/components/canon-universe-graph.ts
+++ b/apps/web/src/components/canon-universe-graph.ts
@@ -1,0 +1,554 @@
+import { appStore } from '../state/app-store';
+import type { AppState } from '../state/app-store';
+import type { UniverseGraph } from '../services/api';
+
+type NVLCreateFn = (config: NVLVisualizationConfig) => NVLInstance;
+
+type NVLVisualizationConfig = {
+  container: HTMLElement;
+  initialGraph?: NVLGraphPayload;
+  data?: NVLGraphPayload;
+  graph?: NVLGraphPayload;
+  style?: Record<string, unknown>;
+};
+
+type NVLModule = {
+  createVisualization?: NVLCreateFn;
+  create?: NVLCreateFn;
+  default?: NVLModule | NVLCreateFn;
+  Visualization?: new (config: NVLVisualizationConfig) => NVLInstance;
+  [key: string]: unknown;
+};
+
+type NVLInstance = {
+  destroy?: () => void;
+  render?: (graph: NVLGraphPayload) => void;
+  update?: (graph: NVLGraphPayload) => void;
+  setData?: (graph: NVLGraphPayload) => void;
+  updateWithData?: (graph: NVLGraphPayload) => void;
+  setGraph?: (graph: NVLGraphPayload) => void;
+  setGraphData?: (graph: NVLGraphPayload) => void;
+  [key: string]: unknown;
+};
+
+type NVLNodePayload = {
+  id: string;
+  labels: string[];
+  properties: Record<string, unknown>;
+  caption?: string;
+};
+
+type NVLRelationshipPayload = {
+  id: string;
+  type: string;
+  startNodeId: string;
+  endNodeId: string;
+  start?: string;
+  end?: string;
+  source?: string;
+  target?: string;
+  caption?: string;
+  properties: Record<string, unknown>;
+};
+
+type NVLGraphPayload = {
+  nodes: NVLNodePayload[];
+  relationships: NVLRelationshipPayload[];
+};
+
+class CanonUniverseGraph extends HTMLElement {
+  private unsubscribe?: () => void;
+  private state: AppState | null = null;
+  private universeId?: string;
+  private container?: HTMLElement;
+  private viewer?: NVLInstance;
+  private lastGraph?: UniverseGraph;
+  private nvlModulePromise?: Promise<NVLModule | null>;
+  private nvlModule?: NVLModule | null;
+  private nvlError?: string;
+
+  static get observedAttributes(): string[] {
+    return ['universe-id'];
+  }
+
+  connectedCallback(): void {
+    if (!this.shadowRoot) {
+      this.attachShadow({ mode: 'open' });
+    }
+
+    this.universeId = this.getAttribute('universe-id') ?? undefined;
+    this.ensureGraphRequest();
+
+    this.unsubscribe = appStore.subscribe((state) => {
+      this.state = state;
+      this.render();
+    });
+
+    this.render();
+  }
+
+  disconnectedCallback(): void {
+    if (this.unsubscribe) {
+      this.unsubscribe();
+      this.unsubscribe = undefined;
+    }
+
+    this.destroyViewer();
+  }
+
+  attributeChangedCallback(
+    name: string,
+    _oldValue: string | null,
+    newValue: string | null
+  ): void {
+    if (name === 'universe-id') {
+      this.universeId = newValue ?? undefined;
+      this.ensureGraphRequest();
+      this.render();
+    }
+  }
+
+  private ensureGraphRequest(): void {
+    if (this.universeId) {
+      appStore.ensureUniverseGraph(this.universeId);
+    }
+  }
+
+  private render(): void {
+    if (!this.shadowRoot) {
+      return;
+    }
+
+    const universeId = this.universeId;
+    const state = this.state;
+    const loadingGraph = state?.loading.graph ?? false;
+    const storeError = state?.errors.graph;
+    const graphData = universeId && state ? state.universeGraphs[universeId] : undefined;
+
+    if (universeId && !graphData && !loadingGraph && !storeError) {
+      this.ensureGraphRequest();
+    }
+
+    const libraryError = this.nvlError;
+
+    let content = '';
+    let shouldRenderCanvas = false;
+
+    if (!universeId) {
+      content = '<div class="empty">Select a universe to see its graph visualization.</div>';
+    } else if (libraryError) {
+      content = `
+        <div class="error">
+          <p>${libraryError}</p>
+          <button type="button" data-action="retry">Retry</button>
+        </div>
+      `;
+    } else if (storeError) {
+      content = `<div class="error">${storeError}</div>`;
+    } else if (loadingGraph && !graphData) {
+      content = '<div class="loading">Loading graph…</div>';
+    } else if (graphData && graphData.nodes.length === 0) {
+      content = '<div class="empty">This universe does not have any graph data yet.</div>';
+    } else if (graphData) {
+      shouldRenderCanvas = true;
+      const meta = this.renderMeta(graphData, loadingGraph);
+      const overlay = loadingGraph
+        ? '<div class="graph-overlay">Refreshing graph…</div>'
+        : '';
+      content = `
+        <div class="graph-wrapper">
+          ${meta}
+          <div class="graph-canvas" role="application" aria-label="Universe graph visualization"></div>
+          ${overlay}
+        </div>
+      `;
+    } else {
+      content = '<div class="loading">Loading graph…</div>';
+    }
+
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          display: block;
+          min-height: 320px;
+        }
+
+        .graph-shell {
+          background: #ffffff;
+          border-radius: 16px;
+          border: 1px solid rgba(162, 169, 177, 0.24);
+          box-shadow: 0 16px 32px rgba(18, 23, 40, 0.08);
+          padding: 20px;
+          min-height: 320px;
+          display: flex;
+          flex-direction: column;
+          gap: 16px;
+        }
+
+        .graph-wrapper {
+          position: relative;
+          flex: 1;
+          border-radius: 12px;
+          border: 1px solid rgba(162, 169, 177, 0.2);
+          background: linear-gradient(180deg, rgba(248, 249, 253, 0.9), #ffffff);
+          overflow: hidden;
+          min-height: 280px;
+          display: flex;
+          flex-direction: column;
+        }
+
+        .graph-canvas {
+          flex: 1;
+          min-height: 260px;
+        }
+
+        .graph-meta {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+          padding: 12px 16px;
+          font-size: 14px;
+          color: rgba(32, 33, 34, 0.68);
+          flex-wrap: wrap;
+          border-bottom: 1px solid rgba(162, 169, 177, 0.2);
+          background: rgba(255, 255, 255, 0.85);
+        }
+
+        .status-pill {
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+          padding: 6px 10px;
+          border-radius: 999px;
+          background: rgba(51, 102, 204, 0.12);
+          color: #1f409c;
+        }
+
+        .loading,
+        .error,
+        .empty {
+          padding: 28px;
+          text-align: center;
+          border-radius: 12px;
+          border: 1px solid rgba(162, 169, 177, 0.2);
+          background: rgba(255, 255, 255, 0.96);
+          box-shadow: 0 12px 24px rgba(18, 23, 40, 0.08);
+          font-size: 15px;
+        }
+
+        .loading {
+          color: #1f409c;
+          background: rgba(51, 102, 204, 0.08);
+        }
+
+        .empty {
+          color: #0b6952;
+          background: rgba(20, 134, 109, 0.08);
+        }
+
+        .error {
+          color: #861616;
+          background: rgba(215, 51, 51, 0.12);
+          display: grid;
+          gap: 12px;
+        }
+
+        .error button {
+          justify-self: center;
+          border: none;
+          background: #3366cc;
+          color: #ffffff;
+          padding: 8px 18px;
+          border-radius: 999px;
+          font: inherit;
+          cursor: pointer;
+        }
+
+        .graph-overlay {
+          position: absolute;
+          inset: 0;
+          background: rgba(255, 255, 255, 0.85);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-weight: 500;
+          color: #1f409c;
+          pointer-events: none;
+        }
+      </style>
+      <div class="graph-shell">
+        ${content}
+      </div>
+    `;
+
+    if (libraryError) {
+      const retry = this.shadowRoot.querySelector<HTMLButtonElement>('button[data-action="retry"]');
+      if (retry) {
+        retry.onclick = () => this.retryLibrary();
+      }
+      this.destroyViewer();
+      return;
+    }
+
+    if (!shouldRenderCanvas || !graphData) {
+      this.destroyViewer();
+      this.container = undefined;
+      this.lastGraph = undefined;
+      return;
+    }
+
+    this.container = this.shadowRoot.querySelector<HTMLElement>('.graph-canvas') ?? undefined;
+    if (!this.container) {
+      return;
+    }
+
+    if (this.lastGraph === graphData && this.viewer) {
+      return;
+    }
+
+    this.lastGraph = graphData;
+    void this.renderVisualization(graphData);
+  }
+
+  private renderMeta(graph: UniverseGraph, loading: boolean): string {
+    return `
+      <div class="graph-meta">
+        <span class="status-pill">${graph.nodes.length} nodes</span>
+        <span class="status-pill">${graph.relationships.length} relationships</span>
+        ${loading ? '<span class="status-pill">Updating…</span>' : ''}
+      </div>
+    `;
+  }
+
+  private async renderVisualization(graph: UniverseGraph): Promise<void> {
+    if (!this.container) {
+      return;
+    }
+
+    this.destroyViewer();
+
+    const module = await this.loadNVLModule();
+    if (!module) {
+      this.nvlError =
+        'Neo4j Visualization Library could not be loaded. Please check your network connection and try again.';
+      queueMicrotask(() => this.render());
+      return;
+    }
+
+    const payload = this.toNVLGraphPayload(graph);
+    const instance = this.instantiateVisualization(module, payload);
+
+    if (!instance) {
+      this.nvlError =
+        'Unable to initialize the Neo4j visualization. Ensure that the NVL bundle is available.';
+      queueMicrotask(() => this.render());
+      return;
+    }
+
+    this.viewer = instance;
+    this.applyGraphData(instance, payload);
+  }
+
+  private async loadNVLModule(): Promise<NVLModule | null> {
+    if (this.nvlModule) {
+      return this.nvlModule;
+    }
+
+    if (!this.nvlModulePromise) {
+      this.nvlModulePromise = (async () => {
+        try {
+          const module = await import(
+            /* @vite-ignore */ 'https://cdn.jsdelivr.net/npm/@neo4j-nvl/vanilla/+esm'
+          );
+          return this.normalizeModule(module);
+        } catch (error) {
+          console.error('Failed to load NVL module', error);
+          return null;
+        }
+      })();
+    }
+
+    const resolved = await this.nvlModulePromise;
+    this.nvlModule = resolved;
+    return resolved;
+  }
+
+  private normalizeModule(module: unknown): NVLModule | null {
+    if (!module) {
+      return null;
+    }
+
+    if (typeof module === 'function') {
+      return { create: module as NVLCreateFn };
+    }
+
+    if (typeof module === 'object') {
+      return module as NVLModule;
+    }
+
+    return null;
+  }
+
+  private instantiateVisualization(
+    module: NVLModule,
+    payload: NVLGraphPayload
+  ): NVLInstance | undefined {
+    if (!this.container) {
+      return undefined;
+    }
+
+    const config: NVLVisualizationConfig = {
+      container: this.container,
+      initialGraph: payload,
+      data: payload,
+      graph: payload,
+      style: {
+        nodes: {
+          caption: 'caption',
+        },
+      },
+    };
+
+    const factories: Array<NVLCreateFn | undefined> = [
+      typeof module.createVisualization === 'function' ? module.createVisualization : undefined,
+      typeof module.create === 'function' ? module.create : undefined,
+    ];
+
+    if (typeof module.default === 'function') {
+      factories.push(module.default as NVLCreateFn);
+    } else if (
+      module.default &&
+      typeof module.default === 'object' &&
+      typeof (module.default as NVLModule).createVisualization === 'function'
+    ) {
+      factories.push((module.default as NVLModule).createVisualization as NVLCreateFn);
+    }
+
+    for (const factory of factories) {
+      if (!factory) {
+        continue;
+      }
+
+      try {
+        return factory(config);
+      } catch (error) {
+        console.warn('NVL factory invocation failed', error);
+      }
+    }
+
+    if (module.Visualization && typeof module.Visualization === 'function') {
+      try {
+        return new module.Visualization(config);
+      } catch (error) {
+        console.warn('NVL Visualization constructor failed', error);
+      }
+    }
+
+    if (typeof module === 'function') {
+      try {
+        return (module as NVLCreateFn)(config);
+      } catch (error) {
+        console.warn('NVL module invocation failed', error);
+      }
+    }
+
+    return undefined;
+  }
+
+  private applyGraphData(instance: NVLInstance, payload: NVLGraphPayload): void {
+    const updateMethods: Array<keyof NVLInstance> = [
+      'render',
+      'update',
+      'updateWithData',
+      'setData',
+      'setGraph',
+      'setGraphData',
+    ];
+
+    for (const method of updateMethods) {
+      const fn = instance[method];
+      if (typeof fn === 'function') {
+        try {
+          (fn as (graph: NVLGraphPayload) => void).call(instance, payload);
+          return;
+        } catch (error) {
+          console.warn(`NVL update method ${String(method)} failed`, error);
+        }
+      }
+    }
+  }
+
+  private toNVLGraphPayload(graph: UniverseGraph): NVLGraphPayload {
+    const nodes: NVLNodePayload[] = graph.nodes.map((node) => ({
+      id: node.id,
+      labels: [...node.labels],
+      properties: { ...node.properties },
+      caption: this.resolveCaption(node.caption, node.properties, node.id),
+    }));
+
+    const relationships: NVLRelationshipPayload[] = graph.relationships.map((relationship) => ({
+      id: relationship.id,
+      type: relationship.type,
+      startNodeId: relationship.start,
+      endNodeId: relationship.end,
+      start: relationship.start,
+      end: relationship.end,
+      source: relationship.start,
+      target: relationship.end,
+      caption: relationship.type,
+      properties: { ...relationship.properties },
+    }));
+
+    return { nodes, relationships };
+  }
+
+  private resolveCaption(
+    explicitCaption: string | undefined,
+    properties: Record<string, unknown>,
+    fallback: string
+  ): string {
+    if (explicitCaption && explicitCaption.trim().length > 0) {
+      return explicitCaption;
+    }
+
+    const candidates: Array<unknown> = [
+      properties.title,
+      properties.name,
+      properties.id,
+      properties.label,
+    ];
+
+    for (const candidate of candidates) {
+      if (typeof candidate === 'string' && candidate.trim().length > 0) {
+        return candidate.trim();
+      }
+    }
+
+    return fallback;
+  }
+
+  private retryLibrary(): void {
+    this.nvlError = undefined;
+    this.nvlModule = undefined;
+    this.nvlModulePromise = undefined;
+    this.destroyViewer();
+    this.ensureGraphRequest();
+    this.render();
+  }
+
+  private destroyViewer(): void {
+    if (this.viewer && typeof this.viewer.destroy === 'function') {
+      try {
+        this.viewer.destroy();
+      } catch (error) {
+        console.warn('Failed to destroy NVL viewer cleanly', error);
+      }
+    }
+
+    this.viewer = undefined;
+  }
+}
+
+if (!customElements.get('canon-universe-graph')) {
+  customElements.define('canon-universe-graph', CanonUniverseGraph);
+}

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -67,6 +67,26 @@ export interface UniverseCategory {
   pages: UniversePageSummary[];
 }
 
+export interface GraphNode {
+  id: string;
+  labels: string[];
+  properties: Record<string, unknown>;
+  caption?: string;
+}
+
+export interface GraphRelationship {
+  id: string;
+  type: string;
+  start: string;
+  end: string;
+  properties: Record<string, unknown>;
+}
+
+export interface UniverseGraph {
+  nodes: GraphNode[];
+  relationships: GraphRelationship[];
+}
+
 export interface PageMetadata {
   id: string;
   name?: string;
@@ -131,6 +151,12 @@ export async function fetchUniverseCategories(
   const response = await request(`/api/universes/${encodeURIComponent(universeId)}/entities`);
   const payload = (await response.json()) as ApiItemResponse<UniverseCategory[]>;
   return payload?.data ?? [];
+}
+
+export async function fetchUniverseGraph(universeId: string): Promise<UniverseGraph> {
+  const response = await request(`/api/universes/${encodeURIComponent(universeId)}/graph`);
+  const payload = (await response.json()) as ApiItemResponse<UniverseGraph>;
+  return payload?.data ?? { nodes: [], relationships: [] };
 }
 
 export async function fetchPageMetadata(pageId: string): Promise<PageMetadata> {


### PR DESCRIPTION
## Summary
- add graph node/relationship DTOs and a service/controller endpoint that returns a universe graph payload
- extend the web client API and store to cache per-universe graph data and surface a Graph tab in the universe detail view
- introduce a `canon-universe-graph` component that lazy-loads the Neo4j Visualization Library from a CDN and renders the fetched graph with fallback messaging

## Testing
- `npm run lint` *(fails: ESLint configuration missing for @canon/bff workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d40828b6e483248b7cc0b60ec3e01a